### PR TITLE
- implement content negotiation for GET /api endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "@amcharts/amcharts5": "^5.3.16",
         "@amcharts/amcharts5-fonts": "^5.0.1",
         "@amcharts/amcharts5-geodata": "^5.1.1",
+        "accepts": "^1.3.8",
         "bulma": "^0.9.4",
         "express": "^4.18.2",
-        "openai": "^3.3.0"
+        "openai": "^3.3.0",
+        "url-parse": "^1.5.10",
+        "xml2js": "^0.6.0"
       },
       "devDependencies": {
         "nodemon": "^2.0.22"
@@ -2219,6 +2222,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/quote-stream": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -2305,6 +2313,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regression/-/regression-2.0.1.tgz",
       "integrity": "sha512-A4XYsc37dsBaNOgEjkJKzfJlE394IMmUPlI/p3TTI9u3T+2a+eox5Pr/CPUqF0eszeWZJPAc6QkroAhuUpWDJQ=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -2808,6 +2821,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2835,6 +2857,26 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmldoc": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,12 @@
     "@amcharts/amcharts5": "^5.3.16",
     "@amcharts/amcharts5-fonts": "^5.0.1",
     "@amcharts/amcharts5-geodata": "^5.1.1",
+    "accepts": "^1.3.8",
     "bulma": "^0.9.4",
     "express": "^4.18.2",
-    "openai": "^3.3.0"
+    "openai": "^3.3.0",
+    "url-parse": "^1.5.10",
+    "xml2js": "^0.6.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/server/client/index.html
+++ b/server/client/index.html
@@ -35,7 +35,6 @@
     <div id="chartdiv"></div>
       </main>
 
-
     <script type="text/javascript" src="index_homepage.js"></script>
 </body>
 </html>

--- a/server/client/index_homepage.js
+++ b/server/client/index_homepage.js
@@ -1,3 +1,6 @@
+const ACCEPT_TYPE_JSON = "application/json";
+const ACCEPT_TYPE_XML = "application/xml";
+const ACCEPT_TYPE = ACCEPT_TYPE_JSON;
 function openNav() {
   document.getElementById("mySidebar").style.width = "250px";
   document.getElementById("main").style.marginLeft = "250px";
@@ -22,12 +25,16 @@ function update_to_results(){
   // Make an HTTP GET request to the /api endpoint
   const xhr = new XMLHttpRequest();
   xhr.open("GET", "/api?name=" + name);
+  xhr.setRequestHeader('Accept', ACCEPT_TYPE);
   xhr.send();
 
   xhr.onload = function() {
     if (xhr.status === 200) {
+      if(xhr.getResponseHeader('content-type') === "application/xml; charset=utf-8") {
+        console.log("Sorry cannot parse XML in browser.");
+        return;
+      }
       const data = JSON.parse(xhr.responseText);
-
       // Handle the JSON response
       const resultsDiv = document.getElementById('results');
       const name = Object.keys(data)[0];

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,8 @@ const dataModel = require("./data-model.js");
 const historyModel = require("./history-model.js");
 const OpenAiKey = "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";
 const port = 3000
+const accepts = require('accepts'); // content negotiation
+const xml2js = require('xml2js'); // XML Serialization
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'client')));
@@ -84,9 +86,20 @@ async function requestAPI(name){
 
 app.get('/api', async (req,res) => {
     //API CALL => http://localhost:3000/api?name=.....
+    const accept = accepts(req); // retrieve info from req accepts header
+    const type = accept.type(['json', 'xml']); // get type
     let data = await requestAPI(req.query.name);
-    res.set('Content-Type', 'application/json')
-    res.send(data)
+    if(type === 'json'){
+        res.set('Content-Type', 'application/json');
+        res.json(data);
+    } else if (type === 'xml') {
+        res.set('Content-Type', 'application/xml');
+        // make data xml
+        const xmlResponse = new xml2js.Builder().buildObject(data);
+        res.send(xmlResponse);
+    } else {
+        res.status(406).send('Not Acceptable');
+    }
 })
 
 app.get('/names', (req,res)=>{


### PR DESCRIPTION
- endpoint can return JSON or XML according to Accept field of Request Header
- Request Header can be set from FE (index_homepage) using the constant at the beginning of the file
- unfortunately it is not easy to parse XML data on the client (server) since the requires package needed to import the parsing library xml2js is not supported in enironments other than node
- that is why on the client side an error message is printed to the console whenever the content-type of the response is xml